### PR TITLE
hide CID#_baseCache so deepEquals() checks don’t look at it

### DIFF
--- a/cid.js
+++ b/cid.js
@@ -18,7 +18,11 @@ module.exports = multiformats => {
   }
   class CID {
     constructor (cid, ...args) {
-      this._baseCache = new Map()
+      Object.defineProperty(this, '_baseCache', {
+        value: new Map(),
+        writable: false,
+        enumerable: false
+      })
       if (_CID.isCID(cid)) {
         readonly(this, 'version', cid.version)
         readonly(this, 'multihash', cid.multihash)

--- a/index.js
+++ b/index.js
@@ -158,17 +158,21 @@ module.exports = (table = []) => {
   const add = obj => {
     if (Array.isArray(obj)) {
       obj.forEach(add)
+    } else if (typeof obj === 'function') {
+      add(obj(multiformats))
     } else {
       const { code, name, encode, decode } = obj
       _add(code, name, encode, decode)
     }
   }
+
   const multiformats = { parse, add, get, encode, decode }
   multiformats.varint = varint
   multiformats.multicodec = { add, get, encode, decode }
   multiformats.multibase = createMultibase()
   multiformats.multihash = createMultihash(multiformats)
   multiformats.CID = createCID(multiformats)
+
   return multiformats
 }
 module.exports.varint = varint

--- a/index.js
+++ b/index.js
@@ -63,9 +63,12 @@ const createMultibase = () => {
     nameMap.set(name, [prefix, encode, decode])
   }
   const add = obj => {
-    if (Array.isArray(obj)) obj.forEach(o => add(o))
-    const { prefix, name, encode, decode } = obj
-    _add(prefix, name, encode, decode)
+    if (Array.isArray(obj)) {
+      obj.forEach(add)
+    } else {
+      const { prefix, name, encode, decode } = obj
+      _add(prefix, name, encode, decode)
+    }
   }
   const get = id => {
     if (id.length === 1) {
@@ -98,6 +101,18 @@ module.exports = (table = []) => {
   const intMap = new Map()
   const nameMap = new Map()
   const _add = (code, name, encode, decode) => {
+    if (!Number.isInteger(code)) {
+      throw new TypeError('multicodec entry must have an integer code')
+    }
+    if (typeof name !== 'string') {
+      throw new TypeError('multicodec entry must have a string name')
+    }
+    if (encode != null && typeof encode !== 'function') {
+      throw new TypeError('multicodec entry encode parameter must be a function')
+    }
+    if (decode != null && typeof decode !== 'function') {
+      throw new TypeError('multicodec entry decode parameter must be a function')
+    }
     intMap.set(code, [name, encode, decode])
     nameMap.set(name, [code, encode, decode])
   }
@@ -141,9 +156,12 @@ module.exports = (table = []) => {
     return decode(value)
   }
   const add = obj => {
-    if (Array.isArray(obj)) obj.forEach(o => add(o))
-    const { code, name, encode, decode } = obj
-    _add(code, name, encode, decode)
+    if (Array.isArray(obj)) {
+      obj.forEach(add)
+    } else {
+      const { code, name, encode, decode } = obj
+      _add(code, name, encode, decode)
+    }
   }
   const multiformats = { parse, add, get, encode, decode }
   multiformats.varint = varint

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-multiformats",
+  "name": "multiformats",
   "version": "0.0.0",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pre:test": "standard",
     "test:node": "hundreds mocha test/test-*.js",
     "test:browser": "polendina --cleanup test/test-*.js",
-    "test": "npm run test:node && npm run test:browser",
+    "test": "npm run pre:test && npm run test:node && npm run test:browser",
     "coverage": "nyc --reporter=html mocha test/test-*.js && npx st -d coverage -p 8080"
   },
   "keywords": [],

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -1,0 +1,16 @@
+/* globals describe, it */
+'use strict'
+const assert = require('assert')
+const multiformat = require('../')()
+const test = it
+
+describe('errors and type checking', () => {
+  test('add argument validation', () => {
+    assert.throws(() => multiformat.add())
+    assert.throws(() => multiformat.add({ code: 'nope' }), /.*integer code.*/)
+    assert.throws(() => multiformat.add({ code: 200, name: () => {} }), /.*string name.*/)
+    assert.throws(() => multiformat.add({ code: 200, name: 'blip', encode: false }), /.*encode .* function.*/)
+    assert.throws(() => multiformat.add({ code: 200, name: 'blip', encode: () => {}, decode: 'nope' }), /.*decode .* function.*/)
+    assert.doesNotThrow(() => multiformat.add({ code: 200, name: 'blip', encode: () => {}, decode: () => {} }))
+  })
+})

--- a/test/test-legacy.js
+++ b/test/test-legacy.js
@@ -23,7 +23,7 @@ describe('multicodec', async () => {
   multiformats.multicodec.add({
     name: 'custom',
     code: 6787678,
-    encode: o => json.util.serialize({o, l: link.toString() }),
+    encode: o => json.util.serialize({ o, l: link.toString() }),
     decode: buff => {
       const obj = json.util.deserialize(buff)
       obj.l = link
@@ -68,6 +68,6 @@ describe('multicodec', async () => {
     const arr = a => Array.from(a)
     const links = ['/o', '/o/one', '/o/one/two', '/o/one/two/hello', '/o/one/three', '/l']
     same(arr(custom.resolver.tree(fixture)), links)
-    same(arr(json.resolver.tree(json.util.serialize("asdf"))), [])
+    same(arr(json.resolver.tree(json.util.serialize('asdf'))), [])
   })
 })

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -6,35 +6,43 @@ const same = assert.deepStrictEqual
 const multiformats = require('../basics')
 const test = it
 
-const testThrow = (fn, message) => {
-  try {
-    fn()
-  } catch (e) {
-    if (e.message !== message) throw e
-    return
-  }
-  throw new Error('Test failed to throw')
-}
 describe('multicodec', () => {
   const { multicodec } = multiformats
+
   test('encode/decode raw', () => {
     const buff = multicodec.encode(Buffer.from('test'), 'raw')
     same(buff, Buffer.from('test'))
     same(multicodec.decode(buff, 'raw'), Buffer.from('test'))
   })
+
   test('encode/decode json', () => {
     const buff = multicodec.encode({ hello: 'world' }, 'json')
     same(buff, Buffer.from(JSON.stringify({ hello: 'world' })))
     same(multicodec.decode(buff, 'json'), { hello: 'world' })
   })
+
   test('raw cannot encode string', () => {
-    testThrow(() => multicodec.encode('asdf', 'raw'), 'Only buffer instances can be used w/ raw codec')
+    assert.throws(() => multicodec.encode('asdf', 'raw'), /^Error: Only buffer instances can be used w\/ raw codec$/)
   })
+
   test('get failure', () => {
-    testThrow(() => multicodec.get(true), 'Unknown key type')
-    let msg = 'Do not have multiformat entry for "8237440"'
-    testThrow(() => multicodec.get(8237440), msg)
-    msg = 'Do not have multiformat entry for "notfound"'
-    testThrow(() => multicodec.get('notfound'), msg)
+    assert.throws(() => multicodec.get(true), /^Error: Unknown key type$/)
+    let msg = /^Error: Do not have multiformat entry for "8237440"$/
+    assert.throws(() => multicodec.get(8237440), msg)
+    msg = /^Error: Do not have multiformat entry for "notfound"$/
+    assert.throws(() => multicodec.get('notfound'), msg)
+  })
+
+  test('add with function', () => {
+    let calls = 0
+    multicodec.add((...args) => {
+      calls++
+      same(args.length, 1, 'called with single arg')
+      assert(args[0] === multiformats, 'called with multiformats as argument')
+      return { code: 200, name: 'blip', encode: (a) => a[1], decode: (a) => a[2] }
+    })
+    same(calls, 1, 'called exactly once')
+    same(multicodec.encode(['one', 'two', 'three'], 'blip'), 'two', 'new codec encoder was added')
+    same(multicodec.decode(['one', 'two', 'three'], 200), 'three', 'new codec decoder was added')
   })
 })


### PR DESCRIPTION
mainly for testing purposes but also for stringification, make it disappear because it’s not uniquely mapped to the CID properties.

this PR builds on #6, hence the extra fluff that’s not in cid.js